### PR TITLE
Reduce number of Docker layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,28 @@
-FROM alpine
-RUN apk update
-RUN apk add bash
-RUN apk add postgresql-client
-RUN apk add mysql-client
-RUN apk add sqlite
-RUN apk add --update openssl
+FROM alpine:latest
+
+RUN apk update && \
+    apk add bash postgresql-client mysql-client sqlite && \
+    apk add --update openssl
 
 ADD shmig /bin/shmig
 
 ## SHMIG configuration
-ENV TYPE mysql
-ENV HOST localhost
-ENV PORT 3389
-ENV DATABASE db
-ENV LOGIN root
-ENV PASSWORD ''
-ENV ASK_PASSWORD0 0
-ENV MIGRATIONS "/sql"
-ENV MYSQL "/usr/bin/mysql"
-ENV PSQL "/usr/bin/psql"
-ENV SQLITE3 "/usr/bin/sqlite3"
-ENV UP_MARK="====  UP  ===="
-ENV DOWN_MARK="==== DOWN ===="
-ENV COLOR auto
-ENV SCHEMA_TABLE shmig_version
+ENV TYPE mysql \
+    HOST localhost \
+    PORT 3389 \
+    DATABASE db \
+    LOGIN root \
+    PASSWORD root \
+    ASK_PASSWORD0 0 \
+    MIGRATIONS /sql \
+    MYSQL /usr/bin/mysql \
+    PSQL /usr/bin/psql \
+    SQLITE3 /usr/bin/sqlite3 \
+    UP_MARK "====  UP  ====" \
+    DOWN_MARK "==== DOWN ====" \
+    COLOR auto \
+    SCHEMA_TABLE shmig_version
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
+

--- a/README.md
+++ b/README.md
@@ -179,6 +179,14 @@ Efficiency
 
 Because SHMIG is just a shell script it's not a speed champion. Every time a statement is executed new client process is spawned. I didn't experience much issues with speed, but if you'll have then please file an issue and maybe I'll get to that in detail.
 
+Usage with Docker
+-----------------
+Shmig can be used and configured with env vars
+```
+docker run -e PASSWORD=root -e HOST=mariadb -v $(pwd)/migrations:/sql --link mariadb:mariadb mkbucc/shmig:latest -t mysql -d db-name up
+```
+
+
 Todo
 ----
 


### PR DESCRIPTION
- Use only 1 layer for apk installs
- Use only 1 layer for env vars set
- Describe shared volume required to run in Dockerfile (/migrations) with VOLUME instruction
- Small doc on readme for usage sample (with container name/tag)