### PR TITLE
Use "which" to find binaries instead of assuming they are located in …

### DIFF
--- a/shmig
+++ b/shmig
@@ -13,9 +13,9 @@ CONFIG_EXPLICITLY_SET="0"
 ASK_PASSWORD="0"
 MIGRATIONS="./migrations"
 
-MYSQL="/usr/bin/mysql"
-PSQL="/usr/bin/psql"
-SQLITE3="/usr/bin/sqlite3"
+MYSQL=`which mysql`
+PSQL=`which psql`
+SQLITE3=`which sqlite3`
 
 UP_MARK="====  UP  ===="
 DOWN_MARK="==== DOWN ===="


### PR DESCRIPTION
I'm using shmig on osx with postgresql installed via homebrew. It's broken because it assumes the binaries for psql et al, are located in /usr/bin. This change uses "which" to find the binaries.

I think ideally you would be able to specify the binary via command line switch. However, I regard this change in its current form as a step forward.

Feedback would be appreciated!