### PR TITLE
Dockerfile: Multiple env vars set with ENV need `=`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,21 +7,21 @@ RUN apk update && \
 ADD shmig /bin/shmig
 
 ## SHMIG configuration
-ENV TYPE mysql \
-    HOST localhost \
-    PORT 3389 \
-    DATABASE db \
-    LOGIN root \
-    PASSWORD root \
-    ASK_PASSWORD0 0 \
-    MIGRATIONS /sql \
-    MYSQL /usr/bin/mysql \
-    PSQL /usr/bin/psql \
-    SQLITE3 /usr/bin/sqlite3 \
-    UP_MARK "====  UP  ====" \
-    DOWN_MARK "==== DOWN ====" \
-    COLOR auto \
-    SCHEMA_TABLE shmig_version
+ENV TYPE=mysql \
+    HOST=localhost \
+    PORT=3389 \
+    DATABASE=db \
+    LOGIN=root \
+    PASSWORD=root \
+    ASK_PASSWORD=0 \
+    MIGRATIONS=/sql \
+    MYSQL=/usr/bin/mysql \
+    PSQL=/usr/bin/psql \
+    SQLITE3=/usr/bin/sqlite3 \
+    UP_MARK="====  UP  ====" \
+    DOWN_MARK="==== DOWN ====" \
+    COLOR=auto \
+    SCHEMA_TABLE=shmig_version
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Currently the docker image does not properly set the ENV vars. It sets one var `TYPE` as follows
```
TYPE=mysql     HOST localhost     PORT 3389     DATABASE db     LOGIN root     PASSWORD root     ASK_PASSWORD0 0     MIGRATIONS /sql     MYSQL /usr/bin/mysql     PSQL /usr/bin/psql     SQLITE3 /usr/bin/sqlite3     UP_MARK ====  UP  ====     DOWN_MARK ==== DOWN ====     COLOR auto     SCHEMA_TABLE shmig_version
```
As stated in the [Dockerfile reference](https://docs.docker.com/engine/reference/builder/#env)
In order to set multiple variables at one time you need to use the form `ENV <key>=<value> ...`