### PR TITLE
Implemented local override config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,17 @@ Usage
 SHMIG tries to read configuration from the configuration file
 `shmig.conf` in the current working directory.  A sample configuration
 file is [`shmig.conf.example`](https://github.com/naquad/shmig/blob/master/shmig.conf.example).
+
+You can also provide an optional config override file by creating the file `shmig.local.conf`.
+This allows you to provide a default configuration which is version-controlled with your project,
+then specify a non-version-controlled local config file that you can use to provide
+instance-specific config. (An alternative is to use envrionment variables, though some people
+prefer concrete files to nebulous environment variables.) This works even with custom config
+files specified with the `-c` option.
+
 You can also configure SHMIG from command line, or by using
 environmental variables.  The command line settings have higher
-priority than configuration file or environment settings.
+priority than configuration files or environment settings.
 
 Required options are:
 
@@ -158,7 +166,8 @@ $ ln -s ../prod/1485643154-create_table.sql
         └── 1485648520-testdata.sql
 ```
 
-When applying migrations to test, point shmig to the test directory.
+When applying migrations to test, point shmig to the test directory either
+via the command line or using the local config override file.
 
 Since migrations are applied in order of epoch seconds in the file name,
 this works.

--- a/shmig
+++ b/shmig
@@ -656,6 +656,18 @@ then
   die "Configuration file '$CONFIG' doesn't exist"
 fi
 
+# Include local config, if available (e.g., shmig.local.conf
+LOCAL_CONFIG="${CONFIG%.*}.local.${CONFIG##*.}"
+if [ -e "$LOCAL_CONFIG" ]; then
+  # any error in configuration file should cause failure
+  # to avoid potential database corruption
+  trap 'die "Local configuration failed"' ERR
+  source "$LOCAL_CONFIG"
+  # reset handler
+  trap - ERR
+fi
+
+
 [[ $ASK_PASSWORD -eq 1 ]] && read -s -p "Password: " _PASSWORD
 
 # options from command line have higher priority than configuration

--- a/shmig
+++ b/shmig
@@ -646,7 +646,7 @@ then
   # any error in configuration file should cause failure
   # to avoid potential database corruption
   trap 'die "Configuration failed"' ERR
-  source "$CONFIG"
+  . "$CONFIG"
   # reset handler
   trap - ERR
 elif [[ $CONFIG_EXPLICITLY_SET -eq 1 ]]
@@ -662,7 +662,7 @@ if [ -e "$LOCAL_CONFIG" ]; then
   # any error in configuration file should cause failure
   # to avoid potential database corruption
   trap 'die "Local configuration failed"' ERR
-  source "$LOCAL_CONFIG"
+  . "$LOCAL_CONFIG"
   # reset handler
   trap - ERR
 fi

--- a/test/test_config
+++ b/test/test_config
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+set -e
+
+# find shmig, defaulting to local
+if [ -e "$PWD/shmig" ]; then
+    shmig="$PWD/shmig"
+elif [ -e "$PWD/../shmig" ]; then
+    shmig="$PWD/../shmig"
+elif command -v shmig &>/dev/null; then
+    shmig="$(command -v shmig)"
+else
+    >&2 echo "E: Can't find shmig command. Can't proceed."
+    exit 1
+fi
+
+# Clean the environment, just to be sure
+rm -Rf /tmp/shmig-test
+
+# Create the test filesystem structure and enter it
+mkdir -p /tmp/shmig-test/test{1,2,3,4}
+cd /tmp/shmig-test
+
+# Create normal config file
+cat << EOF > shmig.conf
+TYPE=sqlite3
+DATABASE=test.sqlite3
+MIGRATIONS=test1
+EOF
+
+# Run shmig and test that it created a migration according to the config file
+if ! "$shmig" create test1 >/dev/null; then
+    >&2 echo "E: shmig failed! Can't proceed with test."
+    exit 2
+fi
+if ! find test1 -name '*test1.sql' &>/dev/null; then
+    >&2 echo "E: shmig didn't create the expected migration. Test can't proceed."
+    exit 3
+fi
+
+
+# Now create a local config file and test again
+echo "MIGRATIONS=test2" > shmig.local.conf
+if ! "$shmig" create test2 >/dev/null; then
+    >&2 echo "E: shmig failed! Can't proceed with test."
+    exit 4
+fi
+if ! find test2 -name '*test2.sql' &>/dev/null; then
+    >&2 echo "FAIL: shmig didn't see the local config file."
+    exit 100
+else
+    echo "PASS: shmig used local default config file shmig.local.conf"
+fi
+
+
+# Now let's try a custom config file
+
+# Create custom config file
+cat << EOF > shmig-custom.conf
+TYPE=sqlite3
+DATABASE=test.sqlite3
+MIGRATIONS=test3
+EOF
+
+# Run shmig and test that it created a migration according to the config file
+if ! "$shmig" -c shmig-custom.conf create test3 >/dev/null; then
+    >&2 echo "E: shmig failed! Can't proceed with test."
+    exit 5
+fi
+if ! find test3 -name '*test3.sql' &>/dev/null; then
+    >&2 echo "E: shmig didn't create the expected migration. Test can't proceed."
+    exit 6
+fi
+
+
+# Now create a local config file and test again
+echo "MIGRATIONS=test4" > shmig-custom.local.conf
+if ! "$shmig" -c shmig-custom.conf create test4 >/dev/null; then
+    >&2 echo "E: shmig failed! Can't proceed with test."
+    exit 7
+fi
+if ! find test4 -name '*test4.sql' &>/dev/null; then
+    >&2 echo "FAIL: shmig didn't see the local custom config file."
+    exit 101
+else
+    echo "PASS: shmig used local custom config file shmig-custom.local.conf"
+fi
+
+
+
+# Clean up
+rm -Rf /tmp/shmig-test
+


### PR DESCRIPTION
This PR allows users to specify a local configuration file `shmig.local.conf` that they can ignore from version control, such that they may specify instance-specific configs that override the default configs in `shmig.conf`.

This is a scheme I much prefer to environment variables, as there is virtually no devops overhead -- you just add the configs in the local file and any user that runs the program will have access to them.

This can be used to easily implement multiple environments, as you've demonstrated with `prod` vs `test`, among other things.

Also, if you haven't seen [bash_unit](https://github.com/pgrange/bash_unit), I've found it to be pretty cool. I didn't use it here because I didn't want to disrupt your test flow, but thought you might like to know :).