### PR TITLE
fix shellcheck warnings and add `make lint` to invoke it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ install: ${PREFIX}/bin/shmig
 ${PREFIX}/bin/shmig: shmig
 	cp $? $@
 
-.PHONY: test
+.PHONY: test lint
+
 test:
 	(cd test ; make)
+
+lint:
+	shellcheck shmig

--- a/shmig
+++ b/shmig
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2155
 
 # SHMIG. Database migration tool in BASH.
 # Copyright 2013 naquad <naquad@gmail.com>
@@ -13,9 +14,9 @@ CONFIG_EXPLICITLY_SET="0"
 ASK_PASSWORD="0"
 MIGRATIONS="./migrations"
 
-MYSQL=`which mysql`
-PSQL=`which psql`
-SQLITE3=`which sqlite3`
+MYSQL=$(command -v mysql)
+PSQL=$(command -v psql)
+SQLITE3=$(command -v sqlite3)
 
 UP_MARK="====  UP  ===="
 DOWN_MARK="==== DOWN ===="
@@ -28,26 +29,19 @@ COLOR="never"
 # we assume color output is not used
 
 RED=""
-GREEN=""
-YELLOW=""
-BLUE=""
-MAGENTA=""
 CYAN=""
-LGRAY=""
-DGRAY=""
 LRED=""
 LGREEN=""
 LYELLOW=""
 LBLUE=""
 LMAGENTA=""
 LCYAN=""
-LWHITE=""
 CLEAR=""
 BOLD=""
 
 # some helpers
 warn(){
-  echo -e "$ME: $@" >&2
+  echo -e "$ME: $*" >&2
 }
 
 die(){
@@ -166,8 +160,7 @@ __generic_checker(){
 
   TMPF=/tmp/$(((RANDOM<<15)|RANDOM)).$$.out
   rm -f $TMPF
-  "${TYPE}_cli" "$show" > $TMPF
-  if [ $? -ne 0 ]
+  if ! "${TYPE}_cli" "$show" > $TMPF
   then
     rm -f $TMPF
     return 1
@@ -212,18 +205,18 @@ __generic_status(){
 
 ##### MySQL
 mysql_cli(){
-  local args="-N -A -B $ARGS $DATABASE"
+  local args=(-N -A -B "$ARGS" "$DATABASE")
 
-  [[ -n $LOGIN    ]] && args="-u $LOGIN    $args"
-  [[ -n $HOST     ]] && args="-h $HOST     $args"
-  [[ -n $PORT     ]] && args="-P $PORT     $args"
+  [[ -n $LOGIN    ]] && args+=("-u" "$LOGIN")
+  [[ -n $HOST     ]] && args+=("-h" "$HOST")
+  [[ -n $PORT     ]] && args+=("-P" "$PORT")
   [[ -n $PASSWORD ]] && export MYSQL_PWD="$PASSWORD"
 
   if [[ $# -ne 0 ]]
   then
-    "$MYSQL" $args <<< $*
+    "$MYSQL" "${args[@]}" "$ARGS" "$DATABASE" <<< "$@"
   else
-    "$MYSQL" $args
+    "$MYSQL" "${args[@]}" "$ARGS" "$DATABASE"
   fi
 }
 
@@ -250,7 +243,7 @@ mysql_status(){
 }
 
 mysql_up_text() {
-cat >> $1 << EOF
+cat >> "$1" << EOF
 BEGIN;
 
 COMMIT;
@@ -259,7 +252,7 @@ EOF
 
 
 mysql_down_text() {
-cat >> $1 << EOF
+cat >> "$1" << EOF
 BEGIN;
 
 COMMIT;
@@ -272,18 +265,18 @@ EOF
 
 postgresql_cli(){
   export PGOPTIONS="-c client_min_messages=WARNING"
-  local args="-q -X -v VERBOSITY=terse -v ON_ERROR_STOP=1 -A -t -w -d $DATABASE $ARGS"
+  local args=(-q -X -v "VERBOSITY=terse" -v "ON_ERROR_STOP=1" -A -t -w -d "$DATABASE")
 
-  [[ -n $LOGIN    ]] && args="-U $LOGIN    $args"
-  [[ -n $HOST     ]] && args="-h $HOST     $args"
-  [[ -n $PORT     ]] && args="-p $PORT     $args"
+  [[ -n $LOGIN    ]] && args+=(-U "$LOGIN")
+  [[ -n $HOST     ]] && args+=(-h "$HOST")
+  [[ -n $PORT     ]] && args+=(-p "$PORT")
   [[ -n $PASSWORD ]] && export PGPASSWORD="$PASSWORD"
 
   if [[ $# -ne 0 ]]
   then
-    "$PSQL" $args -c "$*"
+    "$PSQL" "${args[@]}" "$ARGS" -c "$*"
   else
-    "$PSQL" $args
+    "$PSQL" "${args[@]}" "$ARGS"
   fi
 }
 
@@ -311,7 +304,7 @@ postgresql_status(){
 }
 
 postgresql_up_text() {
-cat >> $1 << EOF
+cat >> "$1" << EOF
 BEGIN;
 
 COMMIT;
@@ -320,7 +313,7 @@ EOF
 
 
 postgresql_down_text() {
-cat >> $1 << EOF
+cat >> "$1" << EOF
 BEGIN;
 
 COMMIT;
@@ -332,13 +325,13 @@ EOF
 ##### SQLite3
 
 sqlite3_cli(){
-  local args="-bail -batch $ARGS $DATABASE"
+  local args=(-bail -batch "$ARGS" "$DATABASE")
 
   if [[ $# -ne 0 ]]
   then
-    "$SQLITE3" $args <<< $*
+    "$SQLITE3" "${args[@]}" <<< "$@"
   else
-    "$SQLITE3" $args
+    "$SQLITE3" "${args[@]}"
   fi
 }
 
@@ -366,7 +359,7 @@ sqlite3_status(){
 }
 
 sqlite3_up_text() {
-cat >> $1 << EOF
+cat >> "$1" << EOF
 BEGIN;
 	PRAGMA foreign_keys = ON;
 
@@ -375,7 +368,7 @@ EOF
 }
 
 sqlite3_down_text() {
-cat >> $1 << EOF
+cat >> "$1" << EOF
 BEGIN;
 
 COMMIT;
@@ -462,7 +455,7 @@ create(){
 
 EOF
 
-${TYPE}_up_text $fname
+"${TYPE}_up_text" "$fname"
 
 cat >> "$fname" << EOF
 
@@ -470,7 +463,7 @@ cat >> "$fname" << EOF
 
 EOF
 
-${TYPE}_down_text $fname
+"${TYPE}_down_text" "$fname"
 
   local retval="$?"
 
@@ -481,6 +474,7 @@ ${TYPE}_down_text $fname
 
 # prints N pending migrations sorted by version in ascending order
 # if N is not given then all printed
+ # shellcheck disable=SC2120
 pending_migrations(){
   local last=$("${TYPE}_previous_versions" 1)
   last="${last:-0}"
@@ -501,13 +495,14 @@ pending_migrations(){
 previous_migrations(){
   local version=""
 
-  while read version
+  while read -r version
   do
     local migration=$(find_migrations -name "$version-*.sql")
     [[ -z $migration ]] && die "${LRED}migration version ${LYELLOW}$version ${LRED}can't be found${CLEAR}"
     echo "$migration"
   done < <("${TYPE}_previous_versions" "$1")
 
+  # shellcheck disable=SC2181
   [[ $? -ne 0 ]] && exit 1
 }
 
@@ -516,7 +511,8 @@ pending(){
   [[ $# -ne 0 ]] && die "${LRED}pending takes no arguments${CLEAR}"
 
   local fname=""
-  pending_migrations | while read fname
+  # shellcheck disable=SC2119
+  pending_migrations | while read -r fname
   do
     echo "${fname##*[/\\]}"
   done
@@ -574,7 +570,7 @@ migrate(){
   is_numeric "$stopver" || die "${LYELLOW}TILL${LRED} should be numeric${CLEAR}"
 
   local fname=""
-  while read fname
+  while read -r fname
   do
     local version=$(migration_version "$fname")
     local name=$(migration_name "$fname")
@@ -595,17 +591,17 @@ migrate(){
 
       migration_section "$fname" "$since" "$till" || die "\n  ${LRED}migration in '${LYELLOW}$fname${LRED}' contains no section ${CYAN}$sname${CLEAR}"
       "$version_change_sql" "$version"
-    ) | if "${TYPE}_cli" &> ${error_tmpfile}; then
+    ) | if "${TYPE}_cli" &> "${error_tmpfile}"; then
           echo -e "${BOLD}${LGREEN}done${CLEAR}" >&2
         else
           echo -e "${BOLD}${LRED}error${CLEAR}" >&2
-          cat ${error_tmpfile}
-          rm ${error_tmpfile}
+          cat "${error_tmpfile}"
+          rm "${error_tmpfile}"
           exit 1
         fi
 
     [[ ${PIPESTATUS[0]} -eq 0 && ${PIPESTATUS[1]} -eq 0 ]] || exit 1
-  done < <("$src" $steps)
+  done < <("$src" "$steps")
 }
 
 # a wrapper for migrate that applies migrations
@@ -644,7 +640,7 @@ do
     ?)   exit 1                    ;;
   esac
 done
-shift $(($OPTIND - 1))
+shift $((OPTIND - 1))
 
 # if config exists
 if [[ -e $CONFIG ]]
@@ -652,6 +648,7 @@ then
   # any error in configuration file should cause failure
   # to avoid potential database corruption
   trap 'die "Configuration failed"' ERR
+  # shellcheck source=/dev/null
   . "$CONFIG"
   # reset handler
   trap - ERR
@@ -668,13 +665,14 @@ if [ -e "$LOCAL_CONFIG" ]; then
   # any error in configuration file should cause failure
   # to avoid potential database corruption
   trap 'die "Local configuration failed"' ERR
+  # shellcheck source=/dev/null
   . "$LOCAL_CONFIG"
   # reset handler
   trap - ERR
 fi
 
 
-[[ $ASK_PASSWORD -eq 1 ]] && read -s -p "Password: " _PASSWORD
+[[ $ASK_PASSWORD -eq 1 ]] && read -r -s -p "Password: " _PASSWORD
 
 # options from command line have higher priority than configuration
 # file. if they were given then we overwrite values
@@ -710,20 +708,13 @@ esac
 if [[ $COLOR -eq 0 ]]
 then
   RED="\e[31m"
-  GREEN="\e[32m"
-  YELLOW="\e[33m"
-  BLUE="\e[34m"
-  MAGENTA="\e[35m"
   CYAN="\e[36m"
-  LGRAY="\e[37m"
-  DGRAY="\e[90m"
   LRED="\e[91m"
   LGREEN="\e[92m"
   LYELLOW="\e[93m"
   LBLUE="\e[94m"
   LMAGENTA="\e[95m"
   LCYAN="\e[96m"
-  LWHITE="\e[97m"
   BOLD="\e[1m"
   CLEAR="\e[0m"
 fi


### PR DESCRIPTION
* invoke `shellcheck` via `make lint`
* fix all the warnings

Fixes #34.