### PR TITLE
Entrypoint retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,11 @@ Shmig can be used and configured with env vars
 docker run -e PASSWORD=root -e HOST=mariadb -v $(pwd)/migrations:/sql --link mariadb:mariadb mkbucc/shmig:latest -t mysql -d db-name up
 ```
 
+This will attempt 3 retries of the command before exiting. This can 
+be useful in a docker-compose set up where the SHMIG container `depends_on`
+another DB service within the docker-compose configuration.
+ 
+
 OS Packaging
 ------------
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,26 @@
-#!/usr/bin/env bash
+#!/bin/env bash
+
 export > /shmig.conf
-shmig $@
+
+max_retries=3
+retry=0
+wait=5
+
+while [ $retry -le $max_retries ]
+do
+    shmig $@
+
+    if [ $? -eq 0 ]
+    then
+        retry=$max_retries
+    else
+        let retry++
+        let wait=$wait*$retry 
+    fi
+
+    if [ $retry -le $max_retries ]
+    then
+        echo "Retry $retry/$max_retries in $wait seconds..."
+        sleep $wait
+    fi
+done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 export > /shmig.conf
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 export > /shmig.conf
-
 max_retries=3
 retry=0
 wait=5
@@ -12,7 +11,7 @@ do
 
     if [ $? -eq 0 ]
     then
-        retry=$max_retries
+        let retry=$max_retries+1
     else
         let retry++
         let wait=$wait*$retry 


### PR DESCRIPTION
Hi

I have added a simple retry/back off loop to the entrypoint script. This is very useful when developing in docker-compose or an other environment where there maybe temporary DB connection issues.

It has 4 tries in total, with the 3 retries at 5, 10 and 30 seconds. Which should be enough for a DB container to be ready.

