### PR TITLE
Fix foreign_keys for sqlite

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,15 @@ Quick Start
   -- Created at: 2016-08-06 09:42:44
   -- ====  UP  ====
 
+  PRAGMA foreign_keys = ON;
+
   BEGIN;
-  	PRAGMA foreign_keys = ON;
 
   COMMIT;
 
   -- ==== DOWN ====
+
+  PRAGMA foreign_keys = ON;
 
   BEGIN;
 

--- a/shmig
+++ b/shmig
@@ -375,8 +375,9 @@ sqlite3_status(){
 
 sqlite3_up_text() {
 cat >> "$1" << EOF
+PRAGMA foreign_keys = ON;
+
 BEGIN;
-	PRAGMA foreign_keys = ON;
 
 COMMIT;
 EOF
@@ -384,6 +385,8 @@ EOF
 
 sqlite3_down_text() {
 cat >> "$1" << EOF
+PRAGMA foreign_keys = ON;
+
 BEGIN;
 
 COMMIT;


### PR DESCRIPTION
From https://www.sqlite.org/foreignkeys.html - last paragraph of section 2 

"It is not possible to enable or disable foreign key constraints in the middle of a multi-statement transaction (when SQLite is not in autocommit mode. Attempting to do so does not return an error; it simply has no effect."

This simply moves the call outside the transaction and adds it to the down section as well